### PR TITLE
Decode fix

### DIFF
--- a/src/xfinder/modules/answer_comparator.py
+++ b/src/xfinder/modules/answer_comparator.py
@@ -40,6 +40,8 @@ class Comparator:
                 if type(standard_answer_range) == str:
                     standard_answer_range_list = ast.literal_eval(
                         standard_answer_range)
+                else:  
+                    standard_answer_range_list = standard_answer_range
                 for option in standard_answer_range_list:
                     if option[0] == correct and \
                             extracted.strip().rstrip(".").lower() == option[1].strip().rstrip(".").lower():

--- a/src/xfinder/modules/answer_extractor.py
+++ b/src/xfinder/modules/answer_extractor.py
@@ -126,7 +126,7 @@ class Extractor:
         output_ids = self.model.generate(
             input_ids, max_new_tokens=self.max_tokens, temperature=self.temperature)
         response = self.tokenizer.decode(
-            output_ids[0], skip_special_tokens=True)
+            output_ids[0][input_ids.shape[1]:], skip_special_tokens=True)
         return response.replace(prompt, '').strip()
 
     def generate_output(self, question, llm_output, standard_answer_range) -> str:

--- a/src/xfinder/modules/answer_extractor.py
+++ b/src/xfinder/modules/answer_extractor.py
@@ -127,7 +127,7 @@ class Extractor:
             input_ids, max_new_tokens=self.max_tokens, temperature=self.temperature)
         response = self.tokenizer.decode(
             output_ids[0][input_ids.shape[1]:], skip_special_tokens=True)
-        return response.replace(prompt, '').strip()
+        return response.strip()
 
     def generate_output(self, question, llm_output, standard_answer_range) -> str:
         formatted_query = f'Question: """{question}"""\n\nOutput sentences: """{llm_output}"""\n\nAnswer range: {standard_answer_range}\n\nKey extracted answer: '


### PR DESCRIPTION
When making a local inference, the `Extractor` was not able to return only the generated output; instead, it returned the whole chat history, leading to a final performance equal to 0.
This commit fixes this behaviour by passing only the response instead of prompt+response to the `.decode()` function. #7 

It also fixes a problem in the `.compare()` function of the `Comparator`, where in certain cases the variable `standard_answer_range_list` was not instantiated.